### PR TITLE
feat: update router to prioritize axial pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ With all the options there is no clear way of knowing which exchange will offer 
 
 ## How it works
 
-Axial Aggregator solves these problems by finding and executing the most profitable trades for users.
+Axial Aggregator solves these problems by finding and executing the most profitable trades for users. The Axial Aggregator works by finding the best path between two tokens using Axial pools, if a path is not found non Axial pools will be used.
+
 * Multi-path trades (e.g. Pangolin > Gondola > Zero)
 * Gas-cost considerations
 * Easy to build on top of

--- a/contracts/AxialRouter.sol
+++ b/contracts/AxialRouter.sol
@@ -577,7 +577,22 @@ contract AxialRouter is Ownable {
     ) internal view returns (Offer memory) {
         Offer memory bestOption = _cloneOffer(_queries);
         uint256 bestAmountOut;
-        // First check if there is a path directly from tokenIn to tokenOut
+
+        // If tokenIn & tokenOut are primary tokens then use primary adapters
+        if(isPrimaryToken(_tokenIn) && isPrimaryToken(_tokenOut)) {
+            Query memory queryPrimary = queryNoSplitPrimary(_amountIn, _tokenIn, _tokenOut);
+            if(queryPrimary.amountOut != 0) {
+                _addQuery(
+                    bestOption, 
+                    queryPrimary.amountOut, 
+                    queryPrimary.adapter, 
+                    queryPrimary.tokenOut
+                );
+                return bestOption;
+            }
+        }
+
+        // Check if there is a path directly from tokenIn to tokenOut
         Query memory queryDirect = queryNoSplit(_amountIn, _tokenIn, _tokenOut);
         if (queryDirect.amountOut!=0) {
             _addQuery(bestOption, queryDirect.amountOut, queryDirect.adapter, queryDirect.tokenOut);

--- a/test/spec/router/primaryTokens.js
+++ b/test/spec/router/primaryTokens.js
@@ -11,7 +11,7 @@ const testTokenList =  [
     "0x48E6013EcF4d40ce15c5223B62Fc2FE33296C2e4"
 ];
 
-describe.only('Axial Router - Primary Tokens', () => {
+describe('Axial Router - Primary Tokens', () => {
 
     before(async () => {
         [deployer] = await ethers.getSigners();

--- a/test/spec/router/primaryTokens.js
+++ b/test/spec/router/primaryTokens.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+let deployer;
+let router;
+
+const testTokenAddress = "0xd586e7f844cea2f87f50152665bcbc2c279d8d70";
+const testTokenList =  [
+    "0x5302AedD1b484fBe70EFd91Ca0C40785f5B4A69d",
+    "0x2D5Cb006177EF6836c7CC73CE18E9Bb0542CBBe3",
+    "0x48E6013EcF4d40ce15c5223B62Fc2FE33296C2e4"
+];
+
+describe.only('Axial Router - Primary Tokens', () => {
+
+    before(async () => {
+        [deployer] = await ethers.getSigners();
+
+        const BytesManipulationFactory = await ethers.getContractFactory('BytesManipulation')
+        const BytesManipulation = await BytesManipulationFactory.deploy()
+        
+        const AxialRouterFactory = await ethers.getContractFactory('AxialRouter', { 
+            libraries: {
+                'BytesManipulation': BytesManipulation.address
+            } 
+        })
+        router = await AxialRouterFactory.connect(deployer).deploy(
+            ['0x5302AedD1b484fBe70EFd91Ca0C40785f5B4A69d'], 
+            ['0x5302AedD1b484fBe70EFd91Ca0C40785f5B4A69d'], 
+            deployer.address);
+        await router.deployed();
+    })
+
+    beforeEach(async () => {
+        
+    })
+
+    it('Should add/remove address from primary tokens list', async () => {
+        const isPrimaryTokenBefore = await router.isPrimaryToken(testTokenAddress)
+        expect(isPrimaryTokenBefore).to.equal(false)
+
+        await router.connect(deployer).addPrimaryToken(testTokenAddress)
+
+        const isPrimaryTokenAfterAdd = await router.isPrimaryToken(testTokenAddress)
+        expect(isPrimaryTokenAfterAdd).to.equal(true)
+
+        await router.connect(deployer).removePrimaryToken(testTokenAddress)
+
+        const isPrimaryTokenAfterRemove = await router.isPrimaryToken(testTokenAddress)
+        expect(isPrimaryTokenAfterRemove).to.equal(false)
+    }) 
+
+    it('Should revert when removing non-primary token from primary tokens list', async () => {
+        const isPrimaryTokenBefore = await router.isPrimaryToken(testTokenAddress)
+        expect(isPrimaryTokenBefore).to.equal(false)
+
+        await expect(router.connect(deployer).removePrimaryToken(testTokenAddress)).to.be.revertedWith(
+            "AxialRouter: Token is not a primary token"
+          );
+    })
+
+    it('Should add/remove all specified primary tokens', async () => {
+
+        for (let index = 0; index < testTokenList.length; index++) {
+            const testToken = testTokenList[index];
+            const isPrimaryTokenBefore = await router.isPrimaryToken(testToken)
+            expect(isPrimaryTokenBefore).to.equal(false)
+        }
+
+        await router.connect(deployer).addPrimaryTokens(testTokenList)
+        for (let index = 0; index < testTokenList.length; index++) {
+            const testToken = testTokenList[index];
+            const isPrimaryTokenAfterBulkAdd = await router.isPrimaryToken(testToken)
+            expect(isPrimaryTokenAfterBulkAdd).to.equal(true)
+        }
+
+        await router.connect(deployer).removePrimaryTokens(testTokenList)
+        for (let index = 0; index < testTokenList.length; index++) {
+            const testToken = testTokenList[index];
+            const isNotPrimaryTokenAfterBulkRemove = await router.isPrimaryToken(testToken)
+            expect(isNotPrimaryTokenAfterBulkRemove).to.equal(false)
+        }
+    }) 
+})

--- a/test/spec/router/primaryTokens.js
+++ b/test/spec/router/primaryTokens.js
@@ -80,5 +80,5 @@ describe('Axial Router - Primary Tokens', () => {
             const isNotPrimaryTokenAfterBulkRemove = await router.isPrimaryToken(testToken)
             expect(isNotPrimaryTokenAfterBulkRemove).to.equal(false)
         }
-    }) 
+    })
 })

--- a/test/spec/router/primaryTokens.js
+++ b/test/spec/router/primaryTokens.js
@@ -31,10 +31,6 @@ describe('Axial Router - Primary Tokens', () => {
         await router.deployed();
     })
 
-    beforeEach(async () => {
-        
-    })
-
     it('Should add/remove address from primary tokens list', async () => {
         const isPrimaryTokenBefore = await router.isPrimaryToken(testTokenAddress)
         expect(isPrimaryTokenBefore).to.equal(false)


### PR DESCRIPTION
This update changes the query method to check for a path using axial adapters first when swapping tokens included in axial pools.
